### PR TITLE
Upgrade terraform provider

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.17.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -14,7 +14,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.26.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.30.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws  = "~> 2.0"
+    aws  = ">= 2.0"
     null = "~> 2.0"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -953,7 +953,7 @@ resource "aws_s3_bucket" "elb_logs" {
 }
 
 module "dns_hostname" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.7.0"
   enabled = var.dns_zone_id != "" && var.tier == "WebServer" ? true : false
   name    = var.dns_subdomain != "" ? var.dns_subdomain : var.name
   zone_id = var.dns_zone_id

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws  = "~> 2.0"
+    aws  = ">= 2.0"
     null = "~> 2.0"
   }
 }


### PR DESCRIPTION
## what
Makes this module compatible with v3.* of `hashicorp/aws` provider.

## why
Third-party modules that use this one benefit from using the latest version of the provider.

TODO:
- In `examples/complete`, the `https://github.com/cloudposse/terraform-aws-elastic-beanstalk-application` is used. It's not compatible with v3.* of the provider which needs to be fixed. Alternatively, can simply stop using that module.